### PR TITLE
modified output for DataStoreObservation

### DIFF
--- a/test_datasets/reference/hap_hd_obs_reference.txt
+++ b/test_datasets/reference/hap_hd_obs_reference.txt
@@ -1,5 +1,5 @@
 Info for OBS_ID = 23523
-- Start time: 53343.92 s
+- Start time: 53343.92 
 - Pointing pos: RA 83.63 deg / Dec 21.51 deg
 - Observation duration: 1687.0 s
 - Dead-time fraction: 6.240 %

--- a/test_datasets/reference/pa_obs_reference.txt
+++ b/test_datasets/reference/pa_obs_reference.txt
@@ -1,5 +1,5 @@
 Info for OBS_ID = 23523
-- Start time: 53343.92 s
+- Start time: 53343.92
 - Pointing pos: RA 83.63 deg / Dec 21.51 deg
 - Observation duration: 1714.0 s
 - Dead-time fraction: 6.594 %


### PR DESCRIPTION
To be consistent with output of obs after changing tstart to Time (mjd) rather than Unit (second) 