### PR TITLE
Change PSF reference file for HAP

### DIFF
--- a/test_datasets/reference/hap_hd_psf_reference.txt
+++ b/test_datasets/reference/hap_hd_psf_reference.txt
@@ -6,7 +6,7 @@ Energy hi      : size =    18, min =  0.032 TeV, max = 79.621 TeV
 Energy lo      : size =    18, min =  0.020 TeV, max = 50.238 TeV
 Safe energy threshold lo:  0.100 TeV
 Safe energy threshold hi: 100.000 TeV
-68% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.14462529 deg
-68% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.10257674 deg
-95% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.28898374 deg
-95% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.28816604 deg
+68% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.12133583 deg
+68% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.08030065 deg
+95% containment radius at theta = 0.0 deg and E =  1.0 TeV: 0.26497512 deg
+95% containment radius at theta = 0.0 deg and E = 10.0 TeV: 0.19768788 deg


### PR DESCRIPTION
This PR change the containment fraction in the reference file of the HAP psf since there was an error in the psf_analytical.py file in gammapy when it was searching for the parameters of the tripple gauss in offset and energy