### PR TITLE
Remove usage of FluxDistribution as it got remved from gammapy

### DIFF
--- a/notebooks/source_population_model.ipynb
+++ b/notebooks/source_population_model.ipynb
@@ -58,8 +58,7 @@
    "outputs": [],
    "source": [
     "from gammapy.utils.random import sample_powerlaw\n",
-    "from gammapy.astro import population\n",
-    "from gammapy.catalog import FluxDistribution"
+    "from gammapy.astro import population"
    ]
   },
   {
@@ -344,12 +343,7 @@
    },
    "outputs": [],
    "source": [
-    "# TODO: plot GLON, GLAT, FLUX distribution\n",
-    "# TODO: this function is broken at the moment on Python 3. Fix it!\n",
-    "table['S'] = table['flux']\n",
-    "flux_distribution = FluxDistribution(table, label='')\n",
-    "# flux_distribution.plot_integral_count()\n",
-    "#flux_distribution.plot_integral_flux()"
+    "# TODO: plot GLON, GLAT, FLUX distribution\n"
    ]
   },
   {
@@ -402,7 +396,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.5.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
It was removed in https://github.com/gammapy/gammapy/pull/961

(seeing red exclamation marks on my travis sidebar urges me to fix things...)

