### PR TITLE
Add conda env file for gammapy-tutorial; use it from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,37 +7,9 @@ MAINTAINER Gammapy developers <gammapy@googlegroups.com>
 # compilers
 RUN apt-get install -y build-essential
 
-# install dependencies
-RUN conda config --add channels conda-forge
-RUN conda config --add channels astropy
-RUN conda config --add channels sherpa
-
-RUN conda install -q -y python==3.6
-RUN conda install -q -y cython>=0.27
-RUN conda install -q -y numpy>=1.13
-RUN conda install -q -y astropy
-RUN conda install -q -y uncertainties
-RUN conda install -q -y scipy>=0.19.1
-RUN conda install -q -y scikit-image
-RUN conda install -q -y matplotlib>=2.0
-RUN conda install -q -y astropy>=2.0
-RUN conda install -q -y regions>=0.2
-RUN conda install -q -y reproject
-RUN conda install -q -y iminuit
-RUN conda install -q -y healpy
-RUN conda install -q -y photutils
-RUN conda install -q -y aplpy
-RUN conda install -q -y pyyaml
-RUN conda install -q -y sherpa>=4.9.1
-RUN conda install -q -y click
-
-# install good version of Jupyter notebook
-RUN pip install --no-cache-dir notebook==5.*
-
-# install last version of gammapy
-RUN /bin/bash -c "git clone https://github.com/gammapy/gammapy.git && \
-                  cd gammapy && \
-                  python setup.py install"
+# install dependencies, including the dev version of Gammapy
+RUN conda env create -f environment.yml
+RUN source activate gammapy-tutorial
 
 # add gammapy user running the jupyter notebook process
 ENV NB_USER gammapy

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,10 +7,6 @@ MAINTAINER Gammapy developers <gammapy@googlegroups.com>
 # compilers
 RUN apt-get install -y build-essential
 
-# install dependencies, including the dev version of Gammapy
-RUN conda env create -f environment.yml
-RUN source activate gammapy-tutorial
-
 # add gammapy user running the jupyter notebook process
 ENV NB_USER gammapy
 ENV NB_UID 1000
@@ -26,6 +22,10 @@ COPY . ${HOME}
 USER root
 RUN chown -R ${NB_UID} ${HOME}
 USER ${NB_USER}
+
+# install dependencies, including the dev version of Gammapy
+RUN conda env create -f environment.yml
+RUN source activate gammapy-tutorial
 
 # start Jupyter server in notebooks dir
 WORKDIR ${HOME}/notebooks

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ RUN chown -R ${NB_UID} ${HOME}
 USER ${NB_USER}
 
 # install dependencies, including the dev version of Gammapy
-RUN conda env create -f environment.yml
-RUN source activate gammapy-tutorial
+RUN conda env create -f ${HOME}/env.yml
+RUN RUN /bin/bash -c "source activate gammapy-tutorial"
 
 # start Jupyter server in notebooks dir
 WORKDIR ${HOME}/notebooks

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,34 @@
+# Conda environment for Gammapy tutorials
+# Install:    conda env create -f environment.yml
+# Update:     conda env update -f environment.yml
+# Activate:   source activate gammapy-tutorial
+# Deactivate: source deactivate
+name: gammapy-tutorial
+
+channels:
+  - conda-forge
+  - sherpa
+
+dependencies:
+  - python==3.6
+  - cython>=0.27
+  - numpy>=1.13
+  - astropy>=2.0
+  - regions>=0.2
+  - sherpa>=4.9.1
+  - click
+  - pyyaml
+  - scipy>=0.19.1
+  - matplotlib>=2.0
+  - scikit-image
+  - uncertainties
+  - healpy
+  - reproject
+  - photutils
+  - aplpy
+  - ipython
+  - iminuit
+
+  - pip:
+    - git+https://github.com/gammapy/gammapy.git#egg=gammapy
+    - notebook==5.*


### PR DESCRIPTION
This PR adds a conda environment file specifically for the Gammapy tutorials.

The idea is to make it easy for people to set up an environment locally that let's them run the tutorials, and once this is merged and works to get rid of this notebook http://docs.gammapy.org/en/latest/notebooks/tutorial_setup.html and to instead put a short description in http://docs.gammapy.org/en/latest/notebooks.html#set-up with the commands people need to clone gammapy-extra, install conda and this env and start the notebooks (pointing to other install pages for futther details).

I also changed the `Dockerfile` for Binder to install this environment. The motivation here is that this will mean that we only maintain the info on dependencies and versions in one place, and the same is used on Docker and for people locally (and we could / should add a CI build for this as well, the one that runs the notebook tests).

@Bultako @adonath @joleroi  - Can you please review this, or even try it out locally and add / fix things to make it work well?
