### PR TITLE
Add jupyter to gammapy-tutorial env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,8 @@ channels:
 
 dependencies:
   - python==3.6
+  - ipython
+  - jupyter
   - cython>=0.27
   - numpy>=1.13
   - astropy>=2.0
@@ -27,7 +29,6 @@ dependencies:
   - reproject
   - photutils
   - aplpy
-  - ipython
   - iminuit
 
   - pip:


### PR DESCRIPTION
@adonath @robertazanin - This PR adds `jupyter` to the `gammapy-tutorial` conda environment.

I noticed that it was missing, because things didn't work for me. I did this:
```
conda env create -f environment.yml
source activate gammapy-tutorial
jupyter notebook
```
and because I didn't have `jupyter` in my active `gammapy-tutorial` environment, the one that got picked up was from the conda root environment
```
$ type jupyter
jupyter is /Users/deil/software/anaconda3/anaconda3/bin/jupyter
```
and then `import gammapy` gave a `ModuleNotFoundError`, because I didn't have Gammapy installed in my root environment.

@adonath - I suggest you merge this now, and if someone runs into the same issue tomorrow, tell them to `conda install jupyter` into the `gammapy-tutorials` environment.

One small issue is that the `jupyter` conda package also drags in QT which is quite large because it includes the Jupyter QT console, which we don't need. So we might want to change from `jupyter` to some other packages that don't include that, just everything needed for the notebook. But it wasn't clear to me what package(s) those are exactly, and it's not a big problem, so I think at least for now putting "jupyter" is OK.