### PR TITLE
Fix bug on debian apt-get install build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM continuumio/miniconda3
 MAINTAINER Gammapy developers <gammapy@googlegroups.com>
 
 # compilers
-RUN apt-get install -y build-essential
+RUN apt-get update && apt-get install -y build-essential
 
 # install good version of notebook for Binder
 RUN pip install --no-cache-dir notebook==5.*


### PR DESCRIPTION
Binder notebooks fail in the process of creating the Docker container, due to a badly configured command for installing build-essentianls pack for Debian.

This PR fixes the issue.


