### PR TITLE
Fix pip upgrade in binder

### DIFF
--- a/binder.py
+++ b/binder.py
@@ -2,10 +2,11 @@
 It installs software dependencies declared in environment.yml
 in the docker container built for the Binder service.
 """
-import pip
+
 import yaml
 import sys
 import conda.cli
+from pip._internal import main as pip_main
 
 with open("environment.yml") as stream:
     content = yaml.load(stream)
@@ -20,4 +21,4 @@ for pack in content['dependencies']:
         conda.cli.main('conda', 'install',  '-y', '-q', pack)
     else:
         print("RUN pip install {}".format(pack['pip'][0]))
-        pip.main(["install", pack['pip'][0]])
+        pip_main(["install", pack['pip'][0]])


### PR DESCRIPTION
The recent upgrade of `pip` throws a bug when installing `gammapy` with `pip` in the virtual environment of binder. 

There is a comprehensive discussion about `main` function in the `pip` upgrade here: https://github.com/pypa/pip/issues/5240