### PR TITLE
Fix numpy bad install in binder environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ MAINTAINER Gammapy developers <gammapy@googlegroups.com>
 
 # compilers
 RUN apt-get update && apt-get install -y build-essential
-#RUN pip install --upgrade pip 
+RUN pip install --upgrade pip 
 
 # install good version of notebook for Binder
 # RUN pip install --no-cache-dir notebook==5.*

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - jupyterlab
   - jupyterlab_launcher
   - cython>=0.27
-  - numpy>=1.13
+  - numpy==1.13
   - pandas
   - astropy>=2.0
   - regions>=0.2

--- a/environment.yml
+++ b/environment.yml
@@ -16,22 +16,21 @@ dependencies:
   - jupyter
   - jupyterlab
   - jupyterlab_launcher
-  - cython>=0.27
+  - cython
   - numpy==1.13
   - pandas
-  - astropy>=2.0
-  - regions>=0.2
-  - sherpa>=4.9.1
+  - astropy
+  - regions
   - click
   - pyyaml
-  - scipy>=0.19.1
-  - matplotlib>=2.0
+  - scipy
+  - matplotlib
   - scikit-image
   - uncertainties
   - healpy
   - reproject
   - photutils
-  - aplpy
+  - sherpa
   - iminuit
 
   - pip:


### PR DESCRIPTION
In binder environment, the installation of `gammapy` throws exception because of `numpy` bad install (for numpy version >1.13) Moreover, most of the other packages dependencies as `astropy`, `pandas`, etc.  cannot be used because of their dependency with `numpy`