### PR TITLE
Fix jupyterlab access in Binder

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,7 +15,7 @@ dependencies:
   - ipython
   - jupyter
   - jupyterlab
-  - jupyterlab_launcher
+  - jupyterlab_launcher==0.11.2
   - cython
   - numpy==1.13
   - pandas


### PR DESCRIPTION
This PR fixes bug in Binder JupyterLab interface by forcing install of a previous version of `jupyterlab_launcher` in the Docker image. 

Refs:
https://github.com/kubeflow/kubeflow/issues/262
https://github.com/jupyterlab/jupyterlab/issues/3487
