### PR TITLE
Test only notebooks present in tutorials documentation

### DIFF
--- a/notebooks/notebooks.yaml
+++ b/notebooks/notebooks.yaml
@@ -11,7 +11,7 @@
   test: true
   requires:
 - name: background_model
-  test: true
+  test: false
   requires:
 - name: cta_1dc_introduction
   test: true
@@ -20,15 +20,15 @@
   test: true
   requires: sherpa
 - name: cta_sensitivity
-  test: true
+  test: false
   requires:
 - name: cwt
   test: true
   requires:
-- name: fermi_lat
+- name: detect_ts
   test: true
   requires:
-- name: detect_ts
+- name: fermi_lat
   test: true
   requires:
 - name: first_steps
@@ -44,10 +44,10 @@
   test: true
   requires:
 - name: light_curve
-  test: true
+  test: false
   requires: sherpa
 - name: nddata_demo
-  test: true
+  test: false
   requires:
 - name: sed_fitting_gammacat_fermi
   test: true
@@ -71,8 +71,8 @@
   test: true
   requires: sherpa
 - name: spectrum_simulation
-  test: true
+  test: false
   requires: sherpa
 - name: spectrum_simulation_cta
-  test: true
+  test: false
   requires: sherpa


### PR DESCRIPTION
Testing only non-broken notebooks present in the tutorials documentation will fix the last two tests in `gammapy` TravisCI