### PR TITLE
Add print_level=1 to display table results in iminuit fitting

### DIFF
--- a/notebooks/analysis_3d.ipynb
+++ b/notebooks/analysis_3d.ipynb
@@ -632,7 +632,7 @@
     "    edisp=edisp,\n",
     ")\n",
     "\n",
-    "fit.fit()"
+    "fit.fit(opts_minuit={'print_level':1})"
    ]
   },
   {

--- a/notebooks/sed_fitting_gammacat_fermi.ipynb
+++ b/notebooks/sed_fitting_gammacat_fermi.ipynb
@@ -215,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fitter = FluxPointFitter(stat=\"chi2assym\", optimizer=\"minuit\")"
+    "fitter = FluxPointFitter(stat=\"chi2assym\", optimizer=\"minuit\", opts_minuit={'print_level':1})"
    ]
   },
   {

--- a/notebooks/simulate_3d.ipynb
+++ b/notebooks/simulate_3d.ipynb
@@ -638,7 +638,7 @@
     "    psf=psf_kernel,\n",
     ")\n",
     "\n",
-    "fit.fit()"
+    "fit.fit(opts_minuit={'print_level':1})"
    ]
   },
   {

--- a/notebooks/spectrum_pipe.ipynb
+++ b/notebooks/spectrum_pipe.ipynb
@@ -1156,7 +1156,7 @@
    ],
    "source": [
     "ana = SpectrumAnalysisIACT(observations=obs_list, config=config)\n",
-    "ana.run()"
+    "ana.run(opts_minuit={'print_level':1})"
    ]
   },
   {


### PR DESCRIPTION
This PR updates notebooks related with `minuit` fits so to display the results table after fitting.
See https://github.com/gammapy/gammapy/pull/1777